### PR TITLE
Add a Dockerfile for elasticsearch 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ production. An exhaustive list of those Docker images follows:
 * Availability:
   [fundocker/openshift-nginx](https://hub.docker.com/r/fundocker/openshift-nginx/)
 
+### `elasticsearch`
+
+* Source: [Dockerfile](./docker/images/elasticsearch/Dockerfile)
+* Availability:
+  [fundocker/openshift-elasticsearch](https://hub.docker.com/r/fundocker/openshift-elasticsearch/)
+
 ## License
 
 This work is released under the MIT License (see [LICENSE](./LICENSE)).

--- a/docker/images/elasticsearch/Dockerfile
+++ b/docker/images/elasticsearch/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+
+# Random user ID so that OpenShift knows we don't run the process as root
+USER 1001


### PR DESCRIPTION
It is based on the official elastic images:
https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html