### PR TITLE
Add Docker image for elasticsearch 6.3.0

### DIFF
--- a/docker/images/elasticsearch/6.3.0/Dockerfile
+++ b/docker/images/elasticsearch/6.3.0/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.3.0
+
+# Random user ID so that OpenShift knows we don't run the process as root
+USER 1001


### PR DESCRIPTION
## Purpose

We are upgrading https://github.com/openfun/richie/ to Elasticsearch 6.3.0 so we need a Docker image to run it in OpenShift.

## Proposal

This is a copy/paste of the existing image Elasticsearch for version 6.2.4 to build an image from Elasticsearch 6.3.0.