### PR TITLE
🐛(publish) fix CI publishing Docker images to Docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ workflows:
               only: /.*/
 
       # We publish new images for each git tag respecting the following
-      # pattern: <image_name>[:<image_tag>], e.g. nginx or nginx:1.13
+      # pattern: <image_name>[-<image_tag>], e.g. nginx or nginx-1.13
       - publish:
           requires:
             - build-all
@@ -108,7 +108,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^(?!all)([A-Za-z0-9]+)(?:\:([0-9.]+))?/
+              only: /^(?!all)([A-Za-z0-9]+)(?:-([0-9.]+))?/
 
       # We publish all services for each tag respecting the following pattern:
       # all-<date>, e.g. all-20180420


### PR DESCRIPTION
## Purpose

The CI was expecting a tag of the form "nginx:1.13" to publish the image to Docker Hub. It does not work because this is not a valid git tag format.

## Proposal 

We should expect a tag of the form "nginx-1.13".