### PR TITLE
Add Docker image for Elasticsearch 6.3.1

### DIFF
--- a/docker/images/elasticsearch/6.3.1/Dockerfile
+++ b/docker/images/elasticsearch/6.3.1/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.3.1
+
+# Random user ID so that OpenShift knows we don't run the process as root
+USER 1001


### PR DESCRIPTION
## Purpose

Elasticsearch 6.3.1 was released and we want to use it to run [richie](https://github.com/openfun/richie) in production with OpenShift.


## Proposal

Copy/paste the DockerFile already in use for different versions of Elasticsearch 6.