### PR TITLE
Add elasticearch 1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ production. An exhaustive list of those Docker images follows:
 ### `elasticsearch`
 
 * Source: [Dockerfile](./docker/images/elasticsearch)
-* Tags: 0.9, 6.2.4, 6.3.0, 6.3.1
+* Tags: 0.9, 1.5.2, 6.2.4, 6.3.0, 6.3.1
 * Availability:
   [fundocker/openshift-elasticsearch](https://hub.docker.com/r/fundocker/openshift-elasticsearch/)
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ production. An exhaustive list of those Docker images follows:
 ### `elasticsearch`
 
 * Source: [Dockerfile](./docker/images/elasticsearch)
-* Tags: 0.9, 6.2.4
+* Tags: 0.9, 6.2.4, 6.3.0, 6.3.1
 * Availability:
   [fundocker/openshift-elasticsearch](https://hub.docker.com/r/fundocker/openshift-elasticsearch/)
 

--- a/docker/images/elasticsearch/1.5.2/Dockerfile
+++ b/docker/images/elasticsearch/1.5.2/Dockerfile
@@ -1,0 +1,39 @@
+FROM java:8-jre
+
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+
+ENV ELASTICSEARCH_MAJOR 1.5
+ENV ELASTICSEARCH_VERSION ${ELASTICSEARCH_MAJOR}.2
+ENV ELASTICSEARCH_REPO_BASE http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_MAJOR}/debian
+
+RUN echo "deb $ELASTICSEARCH_REPO_BASE stable main" > /etc/apt/sources.list.d/elasticsearch.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends elasticsearch=$ELASTICSEARCH_VERSION && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/share/elasticsearch/bin:$PATH
+
+WORKDIR /usr/share/elasticsearch
+
+# Make sure that the initial directories exist and have the correct permissions
+# for OpenShift.
+# OpenShift will run the elasticsearch with a user with a random UID and a GID
+# 0.
+COPY config ./config
+
+RUN for path in \
+    ./data \
+    ./logs \
+    ./config \
+    ./config/scripts; do \
+    mkdir -p "$path"; \
+    chgrp -R 0 "$path"; \
+    chmod -R g=u "$path"; \
+    done
+
+# We use the elasticsearch user created during the .deb package installation to
+# tell OpenShift that we're not running things as root.
+USER elasticsearch
+
+EXPOSE 9200 9300
+ENTRYPOINT ["elasticsearch"]

--- a/docker/images/elasticsearch/1.5.2/config/logging.yml
+++ b/docker/images/elasticsearch/1.5.2/config/logging.yml
@@ -1,0 +1,12 @@
+es.logger.level: INFO
+rootLogger: ${es.logger.level}, console
+logger:
+  # log action execution errors for easier debugging
+  action: DEBUG
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"


### PR DESCRIPTION
## Purpose

Elasticsearch 1.5.2 is required to run Open edX Forum: https://github.com/edx/cs_comments_service. Thus we need an OpenShift compatible image to integrate this service in our platforms.

## Proposal

We've cooked a new image based on the work already done for the 0.9 release.