### PR TITLE
🐛(circle) fix publication step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,14 @@ jobs:
           command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
 
       # We only publish build images upon new git tags with the following
-      # pattern: <image_name>[:<image_tag>], e.g. nginx or nginx:1.13
+      # pattern: <image_name>[-<image_tag>], e.g. nginx or nginx-1.13
       - run:
           name: Build & publish new service release
           command: |
-            bin/build ${CIRCLE_TAG}
-            bin/publish ${CIRCLE_TAG}
+            target_image=${CIRCLE_TAG//-/:}
+            echo "Will build & publish image: ${target_image}"
+            bin/build ${target_image}
+            bin/publish ${target_image}
 
   publish-all:
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Our building strategy follows:
 1. All images are constantly built when a new pull request is proposed and the
    related branch is merged to `master`.
 2. We publish a new image to DockerHub when the git repository is tagged with a
-   tag matching the following pattern: `<image_name>[:<image_tag>]`, _e.g._
-   `nginx` or `nginx:1.13`.
+   tag matching the following pattern: `<image_name>[-<image_tag>]`, _e.g._
+   `nginx` or `nginx-1.13`.
 3. We publish all images to DocherHub when the git repository is tagged with a
    tag matching the following pattern: `all-<date>`, _e.g._ `all-20180423`.
 


### PR DESCRIPTION
## Purpose

When building and publishing images from git tags, the publish script is expecting a tag with the following pattern: `nginx:1.5.2` which is not a git-tag compatible. 

## Proposal

We now substitute the hyphen with a colon to restore automated images publication.