### PR TITLE
✨(elasticsearch) add Docker image for Elasticsearch 6.6.0

### DIFF
--- a/docker/images/elasticsearch/6.6.0/Dockerfile
+++ b/docker/images/elasticsearch/6.6.0/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.6.0
+
+# Random user ID so that OpenShift knows we don't run the process as root
+USER 1001


### PR DESCRIPTION
## Purpose

We should upgrade our Elasticsearch instances to 6.6.0.

## Proposal

This is a copy/paste of the existing DockerFiles for different versions of Elasticsearch 6.