### PR TITLE
✨(elasticsearch) add Docker image for Elasticsearch 6.6.2

### DIFF
--- a/docker/images/elasticsearch/6.6.2/Dockerfile
+++ b/docker/images/elasticsearch/6.6.2/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.6.2
+
+# Random user ID so that OpenShift knows we don't run the process as root
+USER 1001


### PR DESCRIPTION
## Purpose

We should upgrade our Elasticsearch instances to 6.6.2.

## Proposal

This is a copy/paste of the existing DockerFiles for different versions of Elasticsearch 6.